### PR TITLE
Openshift anti idling

### DIFF
--- a/TheAwesomeBot.js
+++ b/TheAwesomeBot.js
@@ -86,16 +86,18 @@ TheAwesomeBot.prototype.loadCommands = function (cmdList) {
     instance.commands[cmd] = script;
 
     var usageObj = script.usage;
-    var usageStrs = [];
-    if (Array.isArray(usageObj)) {
-      usageObj.forEach(u => usageStrs.push(u));
-    } else {
+    if (usageObj) {
+      var usageStrs = [];
+      if (Array.isArray(usageObj)) {
+        usageObj.forEach(u => usageStrs.push(u));
+      } else {
       usageStrs.push(usageObj.toString());
+      }
+      
+      usageStrs.forEach(u => {
+        instance.usageList += `\n- ${instance.settings.bot_cmd} ${u}`
+      });
     }
-
-    usageStrs.forEach(u => {
-      instance.usageList += `\n- ${instance.settings.bot_cmd} ${u}`
-    });
   });
 };
 

--- a/commands/openshift/openshift.js
+++ b/commands/openshift/openshift.js
@@ -1,0 +1,43 @@
+const http         = require('http'),
+      env          = process.env;
+
+module.exports = {
+  usage: false,
+
+  init: (bot) => {
+    // setup "heartbeat" message
+    const heartbeatChannel = bot.settings.openshift.heartbeat_channel || 'bots';
+    const heartbeatInterval = (bot.settings.openshift.heartbeat_interval_in_minutes || 30) * 1000 * 60;
+    let channel = bot.client.channels.get('name', heartbeatChannel);
+    if (!channel) {
+      channel = bot.client.createChannel(bot.client.servers[0], heartbeatChannel, (err, channel) => {
+        if (err) throw `Couldn't find nor create hearbeat channel "${heartbeatChannel}"`;
+      });
+    }
+    console.log(`Setting up hearbeat messages for #${heartbeatChannel} every ${heartbeatInterval/1000/60} minutes...`);
+    setInterval(function () {
+      const msg = `I'm still alive! - ${(new Date()).toUTCString()}`;
+      bot.client.sendMessage(channel, msg);
+      console.log(msg);
+    }, heartbeatInterval);
+
+    // launch health check server
+    this.server = http.createServer(function (req, res) {
+      let url = req.url;
+      if (url.match(/^\/(health)?$/i)) {
+        res.writeHead(200);
+        res.end();
+      }
+    });
+
+    this.server.listen(env.NODE_PORT || 3000, env.NODE_IP || 'localhost', function () {
+      console.log(`Webserver for health checks launched...`);
+    });
+  },
+
+  run: (bot, message, cmd_args) => {
+    // do nothing
+    return;
+  }
+}
+

--- a/settings.json
+++ b/settings.json
@@ -12,7 +12,12 @@
     "pro",
     "stream",
     "uptime",
-    "vote"
-  ]
+    "vote",
+    "openshift"
+  ],
+  "openshift": {
+    "heartbeat_channel": "bots",
+    "heartbeat_interval_in_minutes": 30
+  }
 }
 


### PR DESCRIPTION
Isn't really a command, as it doesn't respond to anything.
On `init`, it sets up:
- webserver to answer with a HTTP 200 on health check requests (on `/` and `/health`)
- `setInterval` to send a heartbeat message every X minutes to a predefined channel

See `settings.json` for setting up interval and channel for the heartbeat.